### PR TITLE
Fixed population dimension handling in predict_apc.R

### DIFF
--- a/R/predict_apc.R
+++ b/R/predict_apc.R
@@ -142,7 +142,11 @@ predict_apc<-function(object, periods=0, population=NULL, quantiles=c(0.05,0.5,0
   
   pr <- exp(ksi0)/(1+exp(ksi0))
   
-  if (is.null(population))population<-object$data$population
+  if (is.null(population)){
+    population <- t(object$data$population)
+  }else{
+    population <- as.matrix(population)
+  }
   
   n0<-min(dim(population)[1],n2)
   


### PR DESCRIPTION
Thank you very much for this helpful package!

## tl;dr

Fixed a reference to the dimension of `object$data$population` in `predict_acp` to be consistent with those to `object$data$cases`. Problem stems from forced transposition in `bapc` function when saving `population` and `cases`, and leads to incorrect output in `cases` and `cases_period` (ie, predicted case counts/rates).

## Justification

If `population` is not provided as an argument to `predict_apc`, then it defaults to the copy saved during fitting: `population <- object$data$population`. But per the `bamp` function, the `population` (and `cases`) provided during model fitting is always transposed before saving: `population <- t(population)`. So `object$data$population` has size `n_age_groups * n_periods`, as does `object$data$cases`.

This leads to `n0` in `predict_apc` essentially being
```
n0 <- min( dim(object$data$population)[1], dim(object$data$cases)[2] + periods)
```
ie, the transposition in `bapc` is not consistently accounted for, and the comparison in this `min` doesn't make sense.

## Impact

This isn't a problem if user always provides `population` to `predict_apc`, but otherwise this issue:

- uses incorrect population sizes during prediction/forecasting, which would affect model validation (where `population` is likely not to be provided)
- incorrectly limits the forecasting horizon for period effects through `n0` to the number of age groups

I don't believe this affects the correctness of any examples present in the vignettes or documentation. Only the `cases` and `cases_period` elements of the output list seem to be affected.

However, there are two examples that use `predict_apc` without supplying a `population` argument:

- the *Short Introduction to BAMP* vignette (under the *Prediction* section)
- the example for `predict_apc`

In both cases, only the output `pr` is plotted (which is fine), but the `cases` and `cases_period` outputs would be incorrect if users were to follow this example.

## Minor incidental change

Also added conversion of `predict_apc` argument `population` via `as.matrix`. Otherwise, users can't use the same `population` they used when calling `bapc` (which does explicitly convert to matrix).