### PR TITLE
Modernize R-CMD-check workflow (fix failing and deprecated CI)

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -1,10 +1,14 @@
-name: R-CMD-check
-
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+
+name: R-CMD-check
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -16,19 +20,28 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, r: '4.0'}
-          - {os: ubuntu-latest, r: '4.1'}
-          - {os: ubuntu-latest, r: '4.2'}
-          - {os: ubuntu-latest, r: 'devel'}
-          - {os: macOS-latest, r: '4.2'}
-          - {os: windows-latest, r: '4.2'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+          - {os: ubuntu-latest,  r: 'oldrel-2'}
+          - {os: ubuntu-latest,  r: 'oldrel-3'}
+          - {os: macos-15,       r: 'release'}
+          - {os: windows-latest, r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -36,3 +49,6 @@ jobs:
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'


### PR DESCRIPTION
## Summary

The `R-CMD-check` workflow (`.github/workflows/check-standard.yaml`) is an older r-lib/actions template that currently fails on GitHub's runners — on `master` as well as on PRs (e.g. the runs for `master` commit `32399839`). This updates it to the current r-lib/actions standard, resolving all failing jobs, deprecation warnings, and the runner-migration notice.

## What was failing / warning

- **ubuntu-latest R 4.0 / 4.1 — ERROR:** `pak` can no longer solve the dependency graph; those R versions are outside Posit PPM's binary-support window, so the job dies in `setup-r-dependencies` before the package is built.
- **macOS-latest R 4.2 (arm64) — ERROR:** the link step fails with `ld: library 'gfortran' not found`. CRAN's R-4.2 arm64 `Makeconf` points `FLIBS` at a gfortran toolchain that isn't present on the runner. R ≥ 4.3 uses the universal gfortran the runner provides.
- **Node.js 20 deprecation (every job) — WARNING:** `actions/checkout@v4` runs on the deprecated Node 20 runtime.
- **"No files were found … check" (macOS) — WARNING:** a downstream symptom of the macOS build dying before `R CMD check` produced a check directory.
- **"macos-latest will migrate to macOS 26" — NOTICE.**

## What changed

- **Matrix** uses rolling labels instead of pinned pre-4.3 versions: `ubuntu-latest` on `devel / release / oldrel-1 / oldrel-2 / oldrel-3` (R 4.6 → 4.3), plus `macos-15` and `windows-latest` on `release`. Every label sits inside PPM's binary window, so dependency solving always succeeds, and macOS on `release` (R ≥ 4.3) links cleanly with the universal gfortran.
- `actions/checkout@v4` → `@v6` (Node 24), matching the current r-lib template.
- Pinned **`macos-15`** to avoid the `macos-latest` → macOS 26 migration.
- Brought the rest of the file up to the current r-lib/actions `check-standard` template: `setup-pandoc`, `use-public-rspm`, `upload-snapshots`, `build_args`, `permissions: read-all`, and the `GITHUB_PAT` / `R_KEEP_PKG_SOURCE` env.

**Workflow-only change — no package code is touched.** In particular no `src/Makevars` change is needed: the gfortran error was purely an R-version / runner-toolchain mismatch, and the package contains no Fortran sources.
