### PR TITLE
Guard predict_apc() against models with no posterior samples (all chains discarded)

### DIFF
--- a/R/predict_apc.R
+++ b/R/predict_apc.R
@@ -33,6 +33,17 @@
 #' plot(pred$pr[2,11,], main="Predicted rate per agegroup", ylab="p")
 #' }
 predict_apc<-function(object, periods=0, population=NULL, quantiles=c(0.05,0.5,0.95), update=FALSE){
+  ## guard: a model whose MCMC chains were ALL discarded during fitting carries no
+  ## posterior samples (e.g. the sampler collapsed on sparse / near-zero-event data and the
+  ## automatic convergence check removed every chain). Predicting from it reads effect
+  ## dimensions of length 0 and fails with a cryptic error deep in the parallel workers
+  ## ("argument of length 0" / "non-numeric argument to mathematical function"). Stop
+  ## clearly and actionably instead -- mirroring the guard already in checkConvergence().
+  if (length(object$samples) == 0 || is.null(object$samples$intercept))
+    stop("predict_apc: the fitted model has no usable posterior samples -- all MCMC chains ",
+         "were discarded during fitting, so the sampler did not converge (e.g. on sparse or ",
+         "near-zero-event data). Refit with more iterations, added overdispersion or a simpler ",
+         "model, and verify with checkConvergence() before predicting.", call. = FALSE)
   ksi_prognose <-
     function(prepi, vdb, noa, nop, nop2, noc, zmode){
       my<-prepi[1]


### PR DESCRIPTION
## Summary

`predict_apc()` crashes with a cryptic error when given a model whose MCMC chains were **all discarded** during fitting — which happens when the automatic convergence check removes every chain (e.g. the sampler collapses on sparse / near-zero-event data). Such a model has an empty `$samples`.

`checkConvergence()` already guards this case (returns `FALSE`). `predict_apc()` did not, so it read effect dimensions of length 0 and failed deep inside its parallel workers:

```
Error in 2:(noa + 1) : argument of length 0
Warning: all scheduled cores encountered errors in user code
Error: non-numeric argument to mathematical function
```

## Fix

Add the same guard `checkConvergence()` uses at the top of `predict_apc()`, so it stops early with a clear, actionable message instead of crashing:

> predict_apc: the fitted model has no usable posterior samples -- all MCMC chains were discarded during fitting ... Refit with more iterations, added overdispersion or a simpler model, and verify with checkConvergence() before predicting.

## Reproduce (current master)

A `bamp()` fit that loses all chains (sparse/near-zero-event data) leaves `length(model$samples) == 0`; `predict_apc()` on it then crashes as above. With this guard it errors clearly. No behavioural change for valid models — one guard at the top of `R/predict_apc.R`.
